### PR TITLE
Remove default logging targets

### DIFF
--- a/MetroLog.NetCore/LogConfigurator.cs
+++ b/MetroLog.NetCore/LogConfigurator.cs
@@ -13,8 +13,6 @@ namespace MetroLog
         public override LoggingConfiguration CreateDefaultSettings()
         {
             var def = base.CreateDefaultSettings();
-            def.AddTarget(LogLevel.Error, LogLevel.Fatal, new FileSnapshotTarget());
-            def.AddTarget(LogLevel.Trace, LogLevel.Fatal, new EtwTarget());
 
             return def;
         }


### PR DESCRIPTION
Removed FileSnapshotTarget and EtwTarget from default settings.
The default targets make it impossible to turn logging off if so
desired.